### PR TITLE
After commit and after rollback callbacks

### DIFF
--- a/data/src/entity_mysql/system.py
+++ b/data/src/entity_mysql/system.py
@@ -249,8 +249,9 @@ class MySQLEngine(object):
         _connection.pop_transaction()
 
         is_empty_transaction = _connection.is_empty_transaction()
-        if not is_empty_transaction: return
+        if not is_empty_transaction: return False
         self._commit()
+        return True
 
     def rollback(self):
         # retrieves the current connection from the associated
@@ -263,7 +264,7 @@ class MySQLEngine(object):
         # for such situation the current method should return, it's not
         # possible to perform the rollback operation
         is_close = _connection.is_close()
-        if is_close: return
+        if is_close: return False
 
         # in case the current transaction level is zero it's
         # not a valid situation as not transaction is open, must
@@ -280,11 +281,12 @@ class MySQLEngine(object):
         # it's not empty there is no need to rollback the transaction
         # because it's an inner level and no effect should be made
         is_empty_transaction = _connection.is_empty_transaction()
-        if not is_empty_transaction: return
+        if not is_empty_transaction: return False
 
         # runs the "rollback" command in the underlying data base
         # layer, executes the "rollback" operation
         self._rollback()
+        return True
 
     def lock(self, entity_class, id_value = None, fields = None, lock_parents = True):
         # retrieves the table name and id associated
@@ -301,7 +303,7 @@ class MySQLEngine(object):
 
         # validates that the id value is valid as an id
         # attribute, type validation (security consideration)
-        id_value_valid and entity_class._validate_value(table_id, id_value)
+        if id_value_valid: entity_class._validate_value(table_id, id_value)
 
         # converts the table id value into the appropriate
         # SQL representation for query usage (casting) this
@@ -511,6 +513,16 @@ class MySQLEngine(object):
         # the resulting values from the query execution
         return cursor
 
+    @property
+    def transaction_level(self):
+        connection = self.entity_manager.get_connection()
+        _connection = connection._connection
+        return _connection.transaction_level
+
+    @property
+    def is_empty(self):
+        return self.transaction_level == 0
+
     def _commit(self):
         connection = self.entity_manager.get_connection()
         _connection = connection._connection
@@ -599,11 +611,11 @@ class MySQLEngine(object):
 
         # retrieves the database size as the first element
         # of the first retrieved row
-        datbase_size = counts[0][0]
+        database_size = counts[0][0]
 
         # returns the result of the retrieval of the database
         # size from the data source
-        return datbase_size
+        return database_size
 
     def _collate_query(self):
         return "collate utf8_general_ci"
@@ -660,7 +672,8 @@ class MySQLEngine(object):
         # the required field values will lock the appropriate rows)
         query_buffer = colony.StringBuffer()
         query_buffer.write("select %s from %s" % (fields_string, table_name))
-        field_name and field_value and query_buffer.write(" where %s = %s" % (field_name, field_value))
+        if field_name and field_value:
+            query_buffer.write(" where %s = %s" % (field_name, field_value))
         query_buffer.write(" for update")
 
         # retrieves the "final" query value from
@@ -753,8 +766,8 @@ class MySQLEngine(object):
         # uses it to encode the query into the proper query
         # representation (string normalization), then returns
         # it to the caller
-        datbase_encoding = self.get_database_encoding()
-        query = query.encode(datbase_encoding)
+        database_encoding = self.get_database_encoding()
+        query = query.encode(database_encoding)
         return query
 
     def _resolve_operator(self, operator):
@@ -972,7 +985,6 @@ class MySQLConnection(object):
         connection = self.get_connection()
         level = self.transaction_level_map[connection]
         is_empty_transaction = level == 0
-
         return is_empty_transaction
 
     def is_valid_transaction(self):
@@ -1006,6 +1018,11 @@ class MySQLConnection(object):
         self._encoding = result
         return result
 
+    @property
+    def transaction_level(self):
+        connection = self.get_connection()
+        return self.transaction_level_map[connection]
+
     def _database_encoding_query(self, database_name):
         query = "select default_character_set_name from information_schema.schemata where schema_name = '%s'" % database_name
         return query
@@ -1019,11 +1036,11 @@ class MySQLConnection(object):
 
         # retrieves the database encoding as the first element
         # of the first retrieved row
-        datbase_encoding = counts[0][0]
+        database_encoding = counts[0][0]
 
         # returns the result of the retrieval of the database
         # encoding from the data source
-        return datbase_encoding
+        return database_encoding
 
     def _execute_query(self, query, connection = None):
         # retrieves the current connection and creates

--- a/mvc/src/mvc_utils/entity_model.py
+++ b/mvc/src/mvc_utils/entity_model.py
@@ -1831,11 +1831,19 @@ def lock(self, reload = False, entity_manager = None):
     # the entity from the data source
     if reload: self.reload()
 
-def after_commit(self, callable):
-    # @TODO: implement the logic to call the provided callable
-    # after the commit of the current transaction
+def after_commit(self, callable, entity_manager = None):
+    # obtains the reference to the entity manager and registers
+    # the provided callable to be called after the commit of the
+    # currently open data transaction
+    entity_manager = entity_manager or self._entity_manager
+    entity_manager.after_commit(callable)
 
-    pass
+def after_rollback(self, callable, entity_manager = None):
+    # obtains the reference to the entity manager and registers
+    # the provided callable to be called after the rollback of the
+    # currently open data transaction
+    entity_manager = entity_manager or self._entity_manager
+    entity_manager.after_rollback(callable)
 
 def validate_relation(self, id_attribute_value, relation_name, entity_manager = None):
     """

--- a/mvc/src/mvc_utils/entity_model.py
+++ b/mvc/src/mvc_utils/entity_model.py
@@ -1829,6 +1829,12 @@ def lock(self, reload = False, entity_manager = None):
     # the entity from the data source
     if reload: self.reload()
 
+def after_commit(self, callable):
+    # @TODO: implement the logic to call the provided callable
+    # after the commit of the current transaction
+
+    pass
+
 def validate_relation(self, id_attribute_value, relation_name, entity_manager = None):
     """
     Validates a relation of the current entity, checking if was already

--- a/mvc/src/mvc_utils/entity_model.py
+++ b/mvc/src/mvc_utils/entity_model.py
@@ -262,7 +262,8 @@ def _class_get(
     # and using the given options, then in case the retrieval was
     # successful applies the context as the entity model request
     entity_model = entity_manager.get(cls, id_value, options, **kwargs)
-    entity_model and hasattr(entity_model, "set_request") and entity_model.set_request(context)
+    if entity_model and hasattr(entity_model, "set_request"):
+        entity_model.set_request(context)
 
     # in case no entity model was not found for the requested parameters
     # an error must be raised indicating such problems as the retrieval
@@ -489,7 +490,8 @@ def _class_find_one(
     # the entity model request
     entity_models = entity_manager.find(cls, options, **kwargs)
     entity_model = entity_models and entity_models[0] or None
-    entity_model and hasattr(entity_model, "set_request") and entity_model.set_request(context)
+    if entity_model and hasattr(entity_model, "set_request"):
+        entity_model.set_request(context)
 
     # in case no entity model was not found for the requested parameters
     # an error must be raised indicating such problems as the retrieval
@@ -2206,12 +2208,12 @@ def resolve_to_many(self, maps_list, model_class, permissive):
 
     # creates the list to hold the various
     # entities of the "to-many" relation
-    entitites_list = []
+    entities_list = []
 
     # in case the received maps list is an empty
     # sequence symbol, (the relation is meant to be set
     # as empty) returns immediately (empty entities list)
-    if maps_list == [""]: return entitites_list
+    if maps_list == [""]: return entities_list
 
     # retrieves the request associated with the current model, this
     # is going to be use to propagate its setting to the created or loaded
@@ -2279,11 +2281,11 @@ def resolve_to_many(self, maps_list, model_class, permissive):
         # the created entity is added to the list of entities for the relations
         if entity: entity.apply(map, permissive = permissive); entity.set_request(request)
         else: entity = _model_class.new(request, map, permissive = permissive)
-        entitites_list.append(entity)
+        entities_list.append(entity)
 
     # returns the list of entities that were loaded or created for the
     # requested to-many relation
-    return entitites_list
+    return entities_list
 
 def set_context(self, context = None, namespace_name = None, entity_manager = None):
     """


### PR DESCRIPTION
## Description

Support for the `after_commit()` and `after_rollback` callbacks.

This allows one person to schedule a certain operation only if (and when) the current transaction succeeds or fails.